### PR TITLE
geom_bar to geom_histogram upgrade

### DIFF
--- a/Assemblytics_variant_charts.R
+++ b/Assemblytics_variant_charts.R
@@ -95,7 +95,7 @@ for (to_png in c(TRUE,FALSE)) {
                     }
 
                     print(ggplot(filtered_bed,aes(x=size, fill=type)) + 
-                      geom_bar(binwidth=binwidth) + 
+                      geom_histogram(binwidth=binwidth) + 
                       scale_fill_manual(values=big_palette,drop=FALSE) + 
                       facet_grid(type ~ .,drop=FALSE) + 
                       labs(fill="Variant type",x="Variant size",y="Count",title=paste("Variants",comma_format(min_var),"to", comma_format(max_var),"bp")) + 


### PR DESCRIPTION
In new ggplot, geom_bar lacks binwidth parameter. Change to geom_histogram to fix error messages