### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build
+        run: pip install build
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "http://assemblytics.com/"
-Repository = "https://github.com/MariaNattestad/Assemblytics"
+Repository = "https://github.com/MariaNattestad/assemblytics"
 
 [project.scripts]
 assemblytics = "assemblytics.cli:main"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` — triggers on a GitHub Release being published, builds wheel + sdist, then publishes to PyPI using **Trusted Publishers (OIDC)**. No token secrets needed.
- Fixes the `Repository` URL in `pyproject.toml` to use the new lowercase repo name.

## How to activate Trusted Publishing on PyPI

Before the first release, set up the publisher on PyPI:

1. Go to [pypi.org/manage/account/publishing](https://pypi.org/manage/account/publishing/)
2. Add a new publisher:
   - **PyPI project name**: `assemblytics`
   - **Owner**: `MariaNattestad`
   - **Repository**: `assemblytics`
   - **Workflow filename**: `publish.yml`
   - **Environment**: `pypi`
3. Create a GitHub Environment named **`pypi`** in repo Settings → Environments (no secrets needed — OIDC handles auth).

Then create a GitHub Release and the workflow fires automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)